### PR TITLE
remove engine_id from the request parameters

### DIFF
--- a/models.go
+++ b/models.go
@@ -34,8 +34,6 @@ type EnginesResponse struct {
 
 // CompletionRequest is a request for the completions API
 type CompletionRequest struct {
-	// The engine ID
-	EngineID string `json:"engine_id,omitempty"`
 	// A list of string prompts to use.
 	// TODO there are other prompt types here for using token integers that we could add support for.
 	Prompt []string `json:"prompt"`
@@ -82,7 +80,6 @@ type CompletionResponse struct {
 
 // SearchRequest is a request for the document search API
 type SearchRequest struct {
-	EngineID  string   `json:"engine_id"`
 	Documents []string `json:"documents"`
 	Query     string   `json:"query"`
 }


### PR DESCRIPTION
Addressing issue brought up in https://github.com/PullRequestInc/go-gpt3/issues/2

It appears that these `EngineID` parameters on the Completion and Search Requests were remnants of a previous iteration. These parameters are actually path parameters in the URL and not part of the request payload itself so should be removed.