### PR TITLE
feature: set organization via client options

### DIFF
--- a/client_options.go
+++ b/client_options.go
@@ -8,6 +8,14 @@ import (
 // ClientOption are options that can be passed when creating a new client
 type ClientOption func(*client) error
 
+// WithOrg is a client option that allows you to override the organization ID
+func WithOrg(id string) ClientOption {
+	return func(c *client) error {
+		c.idOrg = id
+		return nil
+	}
+}
+
 // WithDefaultEngine is a client option that allows you to override the default engine of the client
 func WithDefaultEngine(engine string) ClientOption {
 	return func(c *client) error {

--- a/gpt3.go
+++ b/gpt3.go
@@ -68,6 +68,7 @@ type client struct {
 	userAgent     string
 	httpClient    *http.Client
 	defaultEngine string
+	idOrg         string
 }
 
 // NewClient returns a new OpenAI GPT-3 API client. An apiKey is required to use the client
@@ -82,6 +83,7 @@ func NewClient(apiKey string, options ...ClientOption) Client {
 		baseURL:       defaultBaseURL,
 		httpClient:    httpClient,
 		defaultEngine: DefaultEngine,
+		idOrg:         "",
 	}
 	for _, o := range options {
 		o(c)
@@ -281,6 +283,9 @@ func (c *client) newRequest(ctx context.Context, method, path string, payload in
 	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
 	if err != nil {
 		return nil, err
+	}
+	if (len(c.idOrg) > 0) {
+		req.Header.Set("OpenAI-Organization", c.idOrg)
 	}
 	req.Header.Set("Content-type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.apiKey))


### PR DESCRIPTION
https://beta.openai.com/docs/api-reference/authentication

Edit: I want to set the correct header if an org ID is specified.