### PR TITLE
Add `logprobs` struct, and correct `N` to be an integer.

### DIFF
--- a/models.go
+++ b/models.go
@@ -61,12 +61,20 @@ type CompletionRequest struct {
 	Stream bool `json:"stream,omitempty"`
 }
 
+// LogprobResult represents logprob result of Choice
+type LogprobResult struct {
+	Tokens        []string             `json:"tokens"`
+	TokenLogprobs []float32            `json:"token_logprobs"`
+	TopLogprobs   []map[string]float32 `json:"top_logprobs"`
+	TextOffset    []int                `json:"text_offset"`
+}
+
 // CompletionResponseChoice is one of the choices returned in the response to the Completions API
 type CompletionResponseChoice struct {
-	Text         string `json:"text"`
-	Index        int    `json:"index"`
-	LogProbs     *int   `json:"logprobs"`
-	FinishReason string `json:"finish_reason"`
+	Text         string        `json:"text"`
+	Index        int           `json:"index"`
+	LogProbs     LogprobResult `json:"logprobs"`
+	FinishReason string        `json:"finish_reason"`
 }
 
 // CompletionResponse is the full response from a request to the completions API

--- a/models.go
+++ b/models.go
@@ -44,7 +44,7 @@ type CompletionRequest struct {
 	// Alternative to temperature for nucleus sampling
 	TopP *float32 `json:"top_p,omitempty"`
 	// How many choice to create for each prompt
-	N *float32 `json:"n"`
+	N *int `json:"n"`
 	// Include the probabilities of most likely tokens
 	LogProbs *int `json:"logprobs"`
 	// Echo back the prompt in addition to the completion


### PR DESCRIPTION
`logprobs` was throwing exceptions whenever any logprob results were returned due to it being a `*int` -- so I added the `LogprobResult` struct definition.

Additionally, `N` is an integer, not a `float32`.