### PR TITLE
Return Token Usage on CompletionResponse

### DIFF
--- a/models.go
+++ b/models.go
@@ -117,6 +117,13 @@ type CompletionResponse struct {
 	Created int                        `json:"created"`
 	Model   string                     `json:"model"`
 	Choices []CompletionResponseChoice `json:"choices"`
+	Usage   CompletionResponseUsage    `json:"usage"`
+}
+
+type CompletionResponseUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
 }
 
 // EditsResponse is the full response from a request to the edits API

--- a/models.go
+++ b/models.go
@@ -120,6 +120,7 @@ type CompletionResponse struct {
 	Usage   CompletionResponseUsage    `json:"usage"`
 }
 
+//CompletionResponseUsage is the object that returns how many tokens the completion's request used
 type CompletionResponseUsage struct {
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`

--- a/models.go
+++ b/models.go
@@ -120,7 +120,7 @@ type CompletionResponse struct {
 	Usage   CompletionResponseUsage    `json:"usage"`
 }
 
-//CompletionResponseUsage is the object that returns how many tokens the completion's request used
+// CompletionResponseUsage is the object that returns how many tokens the completion's request used
 type CompletionResponseUsage struct {
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`


### PR DESCRIPTION
I need to keep track of how much tokens every completion spended in my personal project. I noticed that the OpenAI API returns this information, so it was simple to add to the CompletionResponse

I noticed too that some responses of go-gpt3 already have this kind of data being returned, so I tried to follow the pattern of the `EditsResponseUsage` struct 

This data being available may be helpful for someone in the future =]