### PR TITLE
feat: Support Chat Completions API endpoint

### DIFF
--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -21,6 +21,24 @@ func main() {
 	ctx := context.Background()
 	client := gpt3.NewClient(apiKey)
 
+	chatResp, err := client.ChatCompletion(ctx, gpt3.ChatCompletionRequest{
+		Model: gpt3.GPT3Dot5Turbo,
+		Messages: []gpt3.ChatCompletionRequestMessage{
+			{
+				Role:    "system",
+				Content: "You are a poetry writing assistant",
+			},
+			{
+				Role:    "user",
+				Content: "Roses are red.\nViolets are",
+			},
+		},
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+	log.Printf("%+v\n", chatResp)
+
 	resp, err := client.Completion(ctx, gpt3.CompletionRequest{
 		Prompt: []string{
 			"1\n2\n3\n4",

--- a/gpt3_test.go
+++ b/gpt3_test.go
@@ -57,12 +57,20 @@ func TestRequestCreationFails(t *testing.T) {
 			"Get \"https://api.openai.com/v1/engines/davinci\": request error",
 		},
 		{
+			"ChatCompletion",
+			func() (interface{}, error) {
+				return client.ChatCompletion(ctx, gpt3.ChatCompletionRequest{})
+			},
+			"Post \"https://api.openai.com/v1/chat/completions\": request error",
+		},
+		{
 			"Completion",
 			func() (interface{}, error) {
 				return client.Completion(ctx, gpt3.CompletionRequest{})
 			},
 			"Post \"https://api.openai.com/v1/engines/davinci/completions\": request error",
-		}, {
+		},
+		{
 			"CompletionStream",
 			func() (interface{}, error) {
 				var rsp *gpt3.CompletionResponse
@@ -72,13 +80,15 @@ func TestRequestCreationFails(t *testing.T) {
 				return rsp, client.CompletionStream(ctx, gpt3.CompletionRequest{}, onData)
 			},
 			"Post \"https://api.openai.com/v1/engines/davinci/completions\": request error",
-		}, {
+		},
+		{
 			"CompletionWithEngine",
 			func() (interface{}, error) {
 				return client.CompletionWithEngine(ctx, gpt3.AdaEngine, gpt3.CompletionRequest{})
 			},
 			"Post \"https://api.openai.com/v1/engines/ada/completions\": request error",
-		}, {
+		},
+		{
 			"CompletionStreamWithEngine",
 			func() (interface{}, error) {
 				var rsp *gpt3.CompletionResponse
@@ -88,25 +98,29 @@ func TestRequestCreationFails(t *testing.T) {
 				return rsp, client.CompletionStreamWithEngine(ctx, gpt3.AdaEngine, gpt3.CompletionRequest{}, onData)
 			},
 			"Post \"https://api.openai.com/v1/engines/ada/completions\": request error",
-		}, {
+		},
+		{
 			"Edits",
 			func() (interface{}, error) {
 				return client.Edits(ctx, gpt3.EditsRequest{})
 			},
 			"Post \"https://api.openai.com/v1/edits\": request error",
-		}, {
+		},
+		{
 			"Search",
 			func() (interface{}, error) {
 				return client.Search(ctx, gpt3.SearchRequest{})
 			},
 			"Post \"https://api.openai.com/v1/engines/davinci/search\": request error",
-		}, {
+		},
+		{
 			"SearchWithEngine",
 			func() (interface{}, error) {
 				return client.SearchWithEngine(ctx, gpt3.AdaEngine, gpt3.SearchRequest{})
 			},
 			"Post \"https://api.openai.com/v1/engines/ada/search\": request error",
-		}, {
+		},
+		{
 			"Embeddings",
 			func() (interface{}, error) {
 				return client.Embeddings(ctx, gpt3.EmbeddingsRequest{})
@@ -149,7 +163,7 @@ func TestResponses(t *testing.T) {
 			},
 			&gpt3.EnginesResponse{
 				Data: []gpt3.EngineObject{
-					gpt3.EngineObject{
+					{
 						ID:     "123",
 						Object: "list",
 						Owner:  "owner",
@@ -171,6 +185,30 @@ func TestResponses(t *testing.T) {
 			},
 		},
 		{
+			"ChatCompletion",
+			func() (interface{}, error) {
+				return client.ChatCompletion(ctx, gpt3.ChatCompletionRequest{})
+			},
+			&gpt3.ChatCompletionResponse{
+				ID:      "chatcmpl-123",
+				Object:  "messages",
+				Created: 123456789,
+				Model:   "gpt-3.5-turbo",
+				Choices: []gpt3.ChatCompletionResponseChoice{
+					{
+						Index:        0,
+						FinishReason: "stop",
+						Message: []gpt3.ChatCompletionResponseMessage{
+							{
+								Role:    "assistant",
+								Content: "output",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			"Completion",
 			func() (interface{}, error) {
 				return client.Completion(ctx, gpt3.CompletionRequest{})
@@ -181,13 +219,14 @@ func TestResponses(t *testing.T) {
 				Created: 123456789,
 				Model:   "davinci-12",
 				Choices: []gpt3.CompletionResponseChoice{
-					gpt3.CompletionResponseChoice{
+					{
 						Text:         "output",
 						FinishReason: "stop",
 					},
 				},
 			},
-		}, {
+		},
+		{
 			"CompletionStream",
 			func() (interface{}, error) {
 				var rsp *gpt3.CompletionResponse
@@ -197,7 +236,8 @@ func TestResponses(t *testing.T) {
 				return rsp, client.CompletionStream(ctx, gpt3.CompletionRequest{}, onData)
 			},
 			nil, // streaming responses are tested separately
-		}, {
+		},
+		{
 			"CompletionWithEngine",
 			func() (interface{}, error) {
 				return client.CompletionWithEngine(ctx, gpt3.AdaEngine, gpt3.CompletionRequest{})
@@ -208,13 +248,14 @@ func TestResponses(t *testing.T) {
 				Created: 123456789,
 				Model:   "davinci-12",
 				Choices: []gpt3.CompletionResponseChoice{
-					gpt3.CompletionResponseChoice{
+					{
 						Text:         "output",
 						FinishReason: "stop",
 					},
 				},
 			},
-		}, {
+		},
+		{
 			"CompletionStreamWithEngine",
 			func() (interface{}, error) {
 				var rsp *gpt3.CompletionResponse
@@ -224,35 +265,38 @@ func TestResponses(t *testing.T) {
 				return rsp, client.CompletionStreamWithEngine(ctx, gpt3.AdaEngine, gpt3.CompletionRequest{}, onData)
 			},
 			nil, // streaming responses are tested separately
-		}, {
+		},
+		{
 			"Search",
 			func() (interface{}, error) {
 				return client.Search(ctx, gpt3.SearchRequest{})
 			},
 			&gpt3.SearchResponse{
 				Data: []gpt3.SearchData{
-					gpt3.SearchData{
+					{
 						Document: 1,
 						Object:   "search_result",
 						Score:    40.312,
 					},
 				},
 			},
-		}, {
+		},
+		{
 			"SearchWithEngine",
 			func() (interface{}, error) {
 				return client.SearchWithEngine(ctx, gpt3.AdaEngine, gpt3.SearchRequest{})
 			},
 			&gpt3.SearchResponse{
 				Data: []gpt3.SearchData{
-					gpt3.SearchData{
+					{
 						Document: 1,
 						Object:   "search_result",
 						Score:    40.312,
 					},
 				},
 			},
-		}, {
+		},
+		{
 			"Embeddings",
 			func() (interface{}, error) {
 				return client.Embeddings(ctx, gpt3.EmbeddingsRequest{})

--- a/models.go
+++ b/models.go
@@ -32,6 +32,24 @@ type EnginesResponse struct {
 	Object string         `json:"object"`
 }
 
+// ChatCompletionRequestMessage is a message to use as the context for the chat completion API
+type ChatCompletionRequestMessage struct {
+	// Role is the role is the role of the the message. Can be "system", "user", or "assistant"
+	Role string `json:"role"`
+
+	// Content is the content of the message
+	Content string `json:"content"`
+}
+
+// ChatCompletionRequest is a request for the chat completion API
+type ChatCompletionRequest struct {
+	// Model is the name of the model to use. If not specified, will default to gpt-3.5-turbo.
+	Model string `json:"model"`
+
+	// Messages is a list of messages to use as the context for the chat completion.
+	Messages []ChatCompletionRequestMessage `json:"messages"`
+}
+
 // CompletionRequest is a request for the completions API
 type CompletionRequest struct {
 	// A list of string prompts to use.
@@ -100,6 +118,36 @@ type LogprobResult struct {
 	TokenLogprobs []float32            `json:"token_logprobs"`
 	TopLogprobs   []map[string]float32 `json:"top_logprobs"`
 	TextOffset    []int                `json:"text_offset"`
+}
+
+// ChatCompletionResponseMessage is a message returned in the response to the Chat Completions API
+type ChatCompletionResponseMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// ChatCompletionResponseChoice is one of the choices returned in the response to the Chat Completions API
+type ChatCompletionResponseChoice struct {
+	Index        int                           `json:"index"`
+	FinishReason string                        `json:"finish_reason"`
+	Message      ChatCompletionResponseMessage `json:"message"`
+}
+
+// ChatCompletionsResponseUsage is the object that returns how many tokens the completion's request used
+type ChatCompletionsResponseUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+// ChatCompletionResponse is the full response from a request to the Chat Completions API
+type ChatCompletionResponse struct {
+	ID      string                         `json:"id"`
+	Object  string                         `json:"object"`
+	Created int                            `json:"created"`
+	Model   string                         `json:"model"`
+	Choices []ChatCompletionResponseChoice `json:"choices"`
+	Usage   ChatCompletionsResponseUsage   `json:"usage"`
 }
 
 // CompletionResponseChoice is one of the choices returned in the response to the Completions API


### PR DESCRIPTION
OpenAI made an official ChatGPT API endpoint:
https://openai.com/blog/introducing-chatgpt-and-whisper-apis

The implementation here is modeled after the existing `Completion`
function but follows the documentation and request and response formats
outlined here:
https://platform.openai.com/docs/guides/chat/introduction
