### PR TITLE
Fix compile error in test

### DIFF
--- a/gpt3_test.go
+++ b/gpt3_test.go
@@ -198,11 +198,9 @@ func TestResponses(t *testing.T) {
 					{
 						Index:        0,
 						FinishReason: "stop",
-						Message: []gpt3.ChatCompletionResponseMessage{
-							{
-								Role:    "assistant",
-								Content: "output",
-							},
+						Message: gpt3.ChatCompletionResponseMessage{
+							Role:    "assistant",
+							Content: "output",
 						},
 					},
 				},


### PR DESCRIPTION
This fixes a compile error in the test code. I was getting the following error when I ran `go test` on the `main` branch:

```
%~> go test -v -run TestFoo .
# github.com/PullRequestInc/go-gpt3_test [github.com/PullRequestInc/go-gpt3.test]
./gpt3_test.go:201:16: cannot use []gpt3.ChatCompletionResponseMessage{…} (value of type []gpt3.ChatCompletionResponseMessage) as type gpt3.ChatCompletionResponseMessage in struct literal
FAIL	github.com/PullRequestInc/go-gpt3 [build failed]
FAIL
```