### PR TITLE
Add support for Moderations API endpoint

### DIFF
--- a/gpt3_test.go
+++ b/gpt3_test.go
@@ -127,6 +127,13 @@ func TestRequestCreationFails(t *testing.T) {
 			},
 			"Post \"https://api.openai.com/v1/embeddings\": request error",
 		},
+		{
+			"Moderation",
+			func() (interface{}, error) {
+				return client.Moderation(ctx, gpt3.ModerationRequest{})
+			},
+			"Post \"https://api.openai.com/v1/moderations\": request error",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -310,6 +317,37 @@ func TestResponses(t *testing.T) {
 					PromptTokens: 1,
 					TotalTokens:  2,
 				},
+			},
+		},
+		{
+			"Moderation",
+			func() (interface{}, error) {
+				return client.Moderation(ctx, gpt3.ModerationRequest{})
+			},
+			&gpt3.ModerationResponse{
+				ID:    "123",
+				Model: "text-moderation-001",
+				Results: []gpt3.ModerationResult{{
+					Flagged: false,
+					Categories: gpt3.ModerationCategoryResult{
+						Hate:            false,
+						HateThreatening: false,
+						SelfHarm:        false,
+						Sexual:          false,
+						SexualMinors:    false,
+						Violence:        false,
+						ViolenceGraphic: false,
+					},
+					CategoryScores: gpt3.ModerationCategoryScores{
+						Hate:            0.22714105248451233,
+						HateThreatening: 0.22714105248451233,
+						SelfHarm:        0.005232391878962517,
+						Sexual:          0.01407341007143259,
+						SexualMinors:    0.0038522258400917053,
+						Violence:        0.009223177433013916,
+						ViolenceGraphic: 0.036865197122097015,
+					},
+				}},
 			},
 		},
 	}

--- a/models.go
+++ b/models.go
@@ -286,3 +286,48 @@ type SearchResponse struct {
 	Data   []SearchData `json:"data"`
 	Object string       `json:"object"`
 }
+
+// ModerationRequest is a request for the moderation API.
+type ModerationRequest struct {
+	// Input is the input text that should be classified. Required.
+	Input string `json:"input"`
+	// Model is the content moderation model to use. If not specified, will default to OpenAI API defaults, which is
+	// currently "text-moderation-latest".
+	Model string `json:"model,omitempty"`
+}
+
+// ModerationCategoryResult shows the categories that the moderation classifier flagged the input text for.
+type ModerationCategoryResult struct {
+	Hate            bool `json:"hate"`
+	HateThreatening bool `json:"hate/threatening"`
+	SelfHarm        bool `json:"self-harm"`
+	Sexual          bool `json:"sexual"`
+	SexualMinors    bool `json:"sexual/minors"`
+	Violence        bool `json:"violence"`
+	ViolenceGraphic bool `json:"violence/graphic"`
+}
+
+// ModerationCategoryScores shows the classifier scores for each moderation category.
+type ModerationCategoryScores struct {
+	Hate            float32 `json:"hate"`
+	HateThreatening float32 `json:"hate/threatening"`
+	SelfHarm        float32 `json:"self-harm"`
+	Sexual          float32 `json:"sexual"`
+	SexualMinors    float32 `json:"sexual/minors"`
+	Violence        float32 `json:"violence"`
+	ViolenceGraphic float32 `json:"violence/graphic"`
+}
+
+// ModerationResult represents a single moderation classification result returned by the moderation API.
+type ModerationResult struct {
+	Flagged        bool                     `json:"flagged"`
+	Categories     ModerationCategoryResult `json:"categories"`
+	CategoryScores ModerationCategoryScores `json:"category_scores"`
+}
+
+// ModerationResponse is the full response from a request to the moderation API.
+type ModerationResponse struct {
+	ID      string             `json:"id"`
+	Model   string             `json:"model"`
+	Results []ModerationResult `json:"results"`
+}


### PR DESCRIPTION
This adds support for calling the [Moderations API endpoint](https://platform.openai.com/docs/api-reference/moderations) which is a part of the OpenAI API.

## Manual test

<details>
<summary>main.go contents</summary>

```go
package main

import (
	"context"
	"encoding/json"
	"fmt"
	"os"

	gpt3 "github.com/PullRequestInc/go-gpt3"
)

func main() {
	client := gpt3.NewClient(os.Getenv("OPENAI_API_TOKEN"))
	resp, err := client.Moderation(context.Background(), gpt3.ModerationRequest{Input: "Experiment"})
	if err != nil {
		panic(err)
	}
	jsonBytes, err := json.MarshalIndent(resp, "", "  ")
	if err != nil {
		panic(err)
	}
	fmt.Println(string(jsonBytes))
}
```
</details>

<details>
<summary>go.mod contents</summary>

```go
module github.com/yorinasub17/experiments/gpt3/moderation

go 1.19

require github.com/PullRequestInc/go-gpt3 v1.1.14

replace github.com/PullRequestInc/go-gpt3 => github.com/yorinasub17/go-gpt3 v0.0.0-20230322033212-4be7420a9e1a
```
</details>

<details>
<summary>Run output:</summary>

```
%~> go run .
{
  "id": "modr-6wjiZbyvPmVGpB6uykiQLK0NV8HPY",
  "model": "text-moderation-004",
  "results": [
    {
      "flagged": false,
      "categories": {
        "hate": false,
        "hate/threatening": false,
        "self-harm": false,
        "sexual": false,
        "sexual/minors": false,
        "violence": false,
        "violence/graphic": false
      },
      "category_scores": {
        "hate": 0.000018651568,
        "hate/threatening": 5.507919e-10,
        "self-harm": 2.8584697e-9,
        "sexual": 0.000060261966,
        "sexual/minors": 0.0000026142309,
        "violence": 0.000004531721,
        "violence/graphic": 5.7995995e-9
      }
    }
  ]
}
```
</details>

## Unit test results

<details>
<summary>go test -v .</summary>

```
=== RUN   TestInitNewClient
--- PASS: TestInitNewClient (0.00s)
=== RUN   TestRequestCreationFails
=== RUN   TestRequestCreationFails/Engines
=== RUN   TestRequestCreationFails/Engine
=== RUN   TestRequestCreationFails/ChatCompletion
=== RUN   TestRequestCreationFails/Completion
=== RUN   TestRequestCreationFails/CompletionStream
=== RUN   TestRequestCreationFails/CompletionWithEngine
=== RUN   TestRequestCreationFails/CompletionStreamWithEngine
=== RUN   TestRequestCreationFails/Edits
=== RUN   TestRequestCreationFails/Search
=== RUN   TestRequestCreationFails/SearchWithEngine
=== RUN   TestRequestCreationFails/Embeddings
=== RUN   TestRequestCreationFails/Moderation
--- PASS: TestRequestCreationFails (0.00s)
    --- PASS: TestRequestCreationFails/Engines (0.00s)
    --- PASS: TestRequestCreationFails/Engine (0.00s)
    --- PASS: TestRequestCreationFails/ChatCompletion (0.00s)
    --- PASS: TestRequestCreationFails/Completion (0.00s)
    --- PASS: TestRequestCreationFails/CompletionStream (0.00s)
    --- PASS: TestRequestCreationFails/CompletionWithEngine (0.00s)
    --- PASS: TestRequestCreationFails/CompletionStreamWithEngine (0.00s)
    --- PASS: TestRequestCreationFails/Edits (0.00s)
    --- PASS: TestRequestCreationFails/Search (0.00s)
    --- PASS: TestRequestCreationFails/SearchWithEngine (0.00s)
    --- PASS: TestRequestCreationFails/Embeddings (0.00s)
    --- PASS: TestRequestCreationFails/Moderation (0.00s)
=== RUN   TestResponses
=== RUN   TestResponses/Engines
=== RUN   TestResponses/Engines/bad_status_codes
=== RUN   TestResponses/Engines/success_code_json_decode_failure
=== RUN   TestResponses/Engines/successful_response
=== RUN   TestResponses/Engine
=== RUN   TestResponses/Engine/bad_status_codes
=== RUN   TestResponses/Engine/success_code_json_decode_failure
=== RUN   TestResponses/Engine/successful_response
=== RUN   TestResponses/ChatCompletion
=== RUN   TestResponses/ChatCompletion/bad_status_codes
=== RUN   TestResponses/ChatCompletion/success_code_json_decode_failure
=== RUN   TestResponses/ChatCompletion/successful_response
=== RUN   TestResponses/Completion
=== RUN   TestResponses/Completion/bad_status_codes
=== RUN   TestResponses/Completion/success_code_json_decode_failure
=== RUN   TestResponses/Completion/successful_response
=== RUN   TestResponses/CompletionStream
=== RUN   TestResponses/CompletionStream/bad_status_codes
=== RUN   TestResponses/CompletionStream/success_code_json_decode_failure
=== RUN   TestResponses/CompletionWithEngine
=== RUN   TestResponses/CompletionWithEngine/bad_status_codes
=== RUN   TestResponses/CompletionWithEngine/success_code_json_decode_failure
=== RUN   TestResponses/CompletionWithEngine/successful_response
=== RUN   TestResponses/CompletionStreamWithEngine
=== RUN   TestResponses/CompletionStreamWithEngine/bad_status_codes
=== RUN   TestResponses/CompletionStreamWithEngine/success_code_json_decode_failure
=== RUN   TestResponses/Search
=== RUN   TestResponses/Search/bad_status_codes
=== RUN   TestResponses/Search/success_code_json_decode_failure
=== RUN   TestResponses/Search/successful_response
=== RUN   TestResponses/SearchWithEngine
=== RUN   TestResponses/SearchWithEngine/bad_status_codes
=== RUN   TestResponses/SearchWithEngine/success_code_json_decode_failure
=== RUN   TestResponses/SearchWithEngine/successful_response
=== RUN   TestResponses/Embeddings
=== RUN   TestResponses/Embeddings/bad_status_codes
=== RUN   TestResponses/Embeddings/success_code_json_decode_failure
=== RUN   TestResponses/Embeddings/successful_response
=== RUN   TestResponses/Moderation
=== RUN   TestResponses/Moderation/bad_status_codes
=== RUN   TestResponses/Moderation/success_code_json_decode_failure
=== RUN   TestResponses/Moderation/successful_response
--- PASS: TestResponses (0.00s)
    --- PASS: TestResponses/Engines (0.00s)
        --- PASS: TestResponses/Engines/bad_status_codes (0.00s)
        --- PASS: TestResponses/Engines/success_code_json_decode_failure (0.00s)
        --- PASS: TestResponses/Engines/successful_response (0.00s)
    --- PASS: TestResponses/Engine (0.00s)
        --- PASS: TestResponses/Engine/bad_status_codes (0.00s)
        --- PASS: TestResponses/Engine/success_code_json_decode_failure (0.00s)
        --- PASS: TestResponses/Engine/successful_response (0.00s)
    --- PASS: TestResponses/ChatCompletion (0.00s)
        --- PASS: TestResponses/ChatCompletion/bad_status_codes (0.00s)
        --- PASS: TestResponses/ChatCompletion/success_code_json_decode_failure (0.00s)
        --- PASS: TestResponses/ChatCompletion/successful_response (0.00s)
    --- PASS: TestResponses/Completion (0.00s)
        --- PASS: TestResponses/Completion/bad_status_codes (0.00s)
        --- PASS: TestResponses/Completion/success_code_json_decode_failure (0.00s)
        --- PASS: TestResponses/Completion/successful_response (0.00s)
    --- PASS: TestResponses/CompletionStream (0.00s)
        --- PASS: TestResponses/CompletionStream/bad_status_codes (0.00s)
        --- PASS: TestResponses/CompletionStream/success_code_json_decode_failure (0.00s)
    --- PASS: TestResponses/CompletionWithEngine (0.00s)
        --- PASS: TestResponses/CompletionWithEngine/bad_status_codes (0.00s)
        --- PASS: TestResponses/CompletionWithEngine/success_code_json_decode_failure (0.00s)
        --- PASS: TestResponses/CompletionWithEngine/successful_response (0.00s)
    --- PASS: TestResponses/CompletionStreamWithEngine (0.00s)
        --- PASS: TestResponses/CompletionStreamWithEngine/bad_status_codes (0.00s)
        --- PASS: TestResponses/CompletionStreamWithEngine/success_code_json_decode_failure (0.00s)
    --- PASS: TestResponses/Search (0.00s)
        --- PASS: TestResponses/Search/bad_status_codes (0.00s)
        --- PASS: TestResponses/Search/success_code_json_decode_failure (0.00s)
        --- PASS: TestResponses/Search/successful_response (0.00s)
    --- PASS: TestResponses/SearchWithEngine (0.00s)
        --- PASS: TestResponses/SearchWithEngine/bad_status_codes (0.00s)
        --- PASS: TestResponses/SearchWithEngine/success_code_json_decode_failure (0.00s)
        --- PASS: TestResponses/SearchWithEngine/successful_response (0.00s)
    --- PASS: TestResponses/Embeddings (0.00s)
        --- PASS: TestResponses/Embeddings/bad_status_codes (0.00s)
        --- PASS: TestResponses/Embeddings/success_code_json_decode_failure (0.00s)
        --- PASS: TestResponses/Embeddings/successful_response (0.00s)
    --- PASS: TestResponses/Moderation (0.00s)
        --- PASS: TestResponses/Moderation/bad_status_codes (0.00s)
        --- PASS: TestResponses/Moderation/success_code_json_decode_failure (0.00s)
        --- PASS: TestResponses/Moderation/successful_response (0.00s)
PASS
ok  	github.com/PullRequestInc/go-gpt3	(cached)

[yoriy] ~/projects/github/forks/go-gpt3 git:(features/moderations)                                           [go:1.19.5][njs:18.13.0][tf:1.3.7]
%~> go test -count 1 -v .                                                                                                                  [0]
=== RUN   TestInitNewClient
--- PASS: TestInitNewClient (0.00s)
=== RUN   TestRequestCreationFails
=== RUN   TestRequestCreationFails/Engines
=== RUN   TestRequestCreationFails/Engine
=== RUN   TestRequestCreationFails/ChatCompletion
=== RUN   TestRequestCreationFails/Completion
=== RUN   TestRequestCreationFails/CompletionStream
=== RUN   TestRequestCreationFails/CompletionWithEngine
=== RUN   TestRequestCreationFails/CompletionStreamWithEngine
=== RUN   TestRequestCreationFails/Edits
=== RUN   TestRequestCreationFails/Search
=== RUN   TestRequestCreationFails/SearchWithEngine
=== RUN   TestRequestCreationFails/Embeddings
=== RUN   TestRequestCreationFails/Moderation
--- PASS: TestRequestCreationFails (0.00s)
    --- PASS: TestRequestCreationFails/Engines (0.00s)
    --- PASS: TestRequestCreationFails/Engine (0.00s)
    --- PASS: TestRequestCreationFails/ChatCompletion (0.00s)
    --- PASS: TestRequestCreationFails/Completion (0.00s)
    --- PASS: TestRequestCreationFails/CompletionStream (0.00s)
    --- PASS: TestRequestCreationFails/CompletionWithEngine (0.00s)
    --- PASS: TestRequestCreationFails/CompletionStreamWithEngine (0.00s)
    --- PASS: TestRequestCreationFails/Edits (0.00s)
    --- PASS: TestRequestCreationFails/Search (0.00s)
    --- PASS: TestRequestCreationFails/SearchWithEngine (0.00s)
    --- PASS: TestRequestCreationFails/Embeddings (0.00s)
    --- PASS: TestRequestCreationFails/Moderation (0.00s)
=== RUN   TestResponses
=== RUN   TestResponses/Engines
=== RUN   TestResponses/Engines/bad_status_codes
=== RUN   TestResponses/Engines/success_code_json_decode_failure
=== RUN   TestResponses/Engines/successful_response
=== RUN   TestResponses/Engine
=== RUN   TestResponses/Engine/bad_status_codes
=== RUN   TestResponses/Engine/success_code_json_decode_failure
=== RUN   TestResponses/Engine/successful_response
=== RUN   TestResponses/ChatCompletion
=== RUN   TestResponses/ChatCompletion/bad_status_codes
=== RUN   TestResponses/ChatCompletion/success_code_json_decode_failure
=== RUN   TestResponses/ChatCompletion/successful_response
=== RUN   TestResponses/Completion
=== RUN   TestResponses/Completion/bad_status_codes
=== RUN   TestResponses/Completion/success_code_json_decode_failure
=== RUN   TestResponses/Completion/successful_response
=== RUN   TestResponses/CompletionStream
=== RUN   TestResponses/CompletionStream/bad_status_codes
=== RUN   TestResponses/CompletionStream/success_code_json_decode_failure
=== RUN   TestResponses/CompletionWithEngine
=== RUN   TestResponses/CompletionWithEngine/bad_status_codes
=== RUN   TestResponses/CompletionWithEngine/success_code_json_decode_failure
=== RUN   TestResponses/CompletionWithEngine/successful_response
=== RUN   TestResponses/CompletionStreamWithEngine
=== RUN   TestResponses/CompletionStreamWithEngine/bad_status_codes
=== RUN   TestResponses/CompletionStreamWithEngine/success_code_json_decode_failure
=== RUN   TestResponses/Search
=== RUN   TestResponses/Search/bad_status_codes
=== RUN   TestResponses/Search/success_code_json_decode_failure
=== RUN   TestResponses/Search/successful_response
=== RUN   TestResponses/SearchWithEngine
=== RUN   TestResponses/SearchWithEngine/bad_status_codes
=== RUN   TestResponses/SearchWithEngine/success_code_json_decode_failure
=== RUN   TestResponses/SearchWithEngine/successful_response
=== RUN   TestResponses/Embeddings
=== RUN   TestResponses/Embeddings/bad_status_codes
=== RUN   TestResponses/Embeddings/success_code_json_decode_failure
=== RUN   TestResponses/Embeddings/successful_response
=== RUN   TestResponses/Moderation
=== RUN   TestResponses/Moderation/bad_status_codes
=== RUN   TestResponses/Moderation/success_code_json_decode_failure
=== RUN   TestResponses/Moderation/successful_response
--- PASS: TestResponses (0.00s)
    --- PASS: TestResponses/Engines (0.00s)
        --- PASS: TestResponses/Engines/bad_status_codes (0.00s)
        --- PASS: TestResponses/Engines/success_code_json_decode_failure (0.00s)
        --- PASS: TestResponses/Engines/successful_response (0.00s)
    --- PASS: TestResponses/Engine (0.00s)
        --- PASS: TestResponses/Engine/bad_status_codes (0.00s)
        --- PASS: TestResponses/Engine/success_code_json_decode_failure (0.00s)
        --- PASS: TestResponses/Engine/successful_response (0.00s)
    --- PASS: TestResponses/ChatCompletion (0.00s)
        --- PASS: TestResponses/ChatCompletion/bad_status_codes (0.00s)
        --- PASS: TestResponses/ChatCompletion/success_code_json_decode_failure (0.00s)
        --- PASS: TestResponses/ChatCompletion/successful_response (0.00s)
    --- PASS: TestResponses/Completion (0.00s)
        --- PASS: TestResponses/Completion/bad_status_codes (0.00s)
        --- PASS: TestResponses/Completion/success_code_json_decode_failure (0.00s)
        --- PASS: TestResponses/Completion/successful_response (0.00s)
    --- PASS: TestResponses/CompletionStream (0.00s)
        --- PASS: TestResponses/CompletionStream/bad_status_codes (0.00s)
        --- PASS: TestResponses/CompletionStream/success_code_json_decode_failure (0.00s)
    --- PASS: TestResponses/CompletionWithEngine (0.00s)
        --- PASS: TestResponses/CompletionWithEngine/bad_status_codes (0.00s)
        --- PASS: TestResponses/CompletionWithEngine/success_code_json_decode_failure (0.00s)
        --- PASS: TestResponses/CompletionWithEngine/successful_response (0.00s)
    --- PASS: TestResponses/CompletionStreamWithEngine (0.00s)
        --- PASS: TestResponses/CompletionStreamWithEngine/bad_status_codes (0.00s)
        --- PASS: TestResponses/CompletionStreamWithEngine/success_code_json_decode_failure (0.00s)
    --- PASS: TestResponses/Search (0.00s)
        --- PASS: TestResponses/Search/bad_status_codes (0.00s)
        --- PASS: TestResponses/Search/success_code_json_decode_failure (0.00s)
        --- PASS: TestResponses/Search/successful_response (0.00s)
    --- PASS: TestResponses/SearchWithEngine (0.00s)
        --- PASS: TestResponses/SearchWithEngine/bad_status_codes (0.00s)
        --- PASS: TestResponses/SearchWithEngine/success_code_json_decode_failure (0.00s)
        --- PASS: TestResponses/SearchWithEngine/successful_response (0.00s)
    --- PASS: TestResponses/Embeddings (0.00s)
        --- PASS: TestResponses/Embeddings/bad_status_codes (0.00s)
        --- PASS: TestResponses/Embeddings/success_code_json_decode_failure (0.00s)
        --- PASS: TestResponses/Embeddings/successful_response (0.00s)
    --- PASS: TestResponses/Moderation (0.00s)
        --- PASS: TestResponses/Moderation/bad_status_codes (0.00s)
        --- PASS: TestResponses/Moderation/success_code_json_decode_failure (0.00s)
        --- PASS: TestResponses/Moderation/successful_response (0.00s)
PASS
ok  	github.com/PullRequestInc/go-gpt3	0.257s
```
</details>