### PR TITLE
Expose rate limiting headers to responses and errors

### DIFF
--- a/gpt3.go
+++ b/gpt3.go
@@ -185,9 +185,9 @@ func (c *client) ChatCompletion(ctx context.Context, request ChatCompletionReque
 			request.Model = GPT3Dot5Turbo
 		} else {
 			request.Model = GPT3Dot5Turbo0613
-		}		
+		}
 	}
-	
+
 	request.Stream = false
 
 	req, err := c.newRequest(ctx, "POST", "/chat/completions", request)
@@ -204,6 +204,7 @@ func (c *client) ChatCompletion(ctx context.Context, request ChatCompletionReque
 	if err := getResponseObject(resp, output); err != nil {
 		return nil, err
 	}
+	output.RateLimitHeaders = NewRateLimitHeadersFromResponse(resp)
 	return output, nil
 }
 
@@ -276,6 +277,8 @@ func (c *client) CompletionWithEngine(ctx context.Context, engine string, reques
 	if err := getResponseObject(resp, output); err != nil {
 		return nil, err
 	}
+	output.RateLimitHeaders = NewRateLimitHeadersFromResponse(resp)
+
 	return output, nil
 }
 
@@ -440,9 +443,11 @@ func checkForSuccess(resp *http.Response) error {
 			Type:       "Unexpected",
 			Message:    string(data),
 		}
+		apiError.RateLimitHeaders = NewRateLimitHeadersFromResponse(resp)
 		return apiError
 	}
 	result.Error.StatusCode = resp.StatusCode
+	result.Error.RateLimitHeaders = NewRateLimitHeadersFromResponse(resp)
 	return result.Error
 }
 


### PR DESCRIPTION
This exposes the rate limit information [included inside response headers](https://platform.openai.com/docs/guides/rate-limits/rate-limits-in-headers) returned by OpenAI.

It performs a best effort to parse them and ignores errors, as we wouldn't want a call to fail due to failing to deserialize this information.

An example native way to consume these would look like:

```go
var gpt3Err gpt3.APIError
if errors.As(err, &gpt3Err) {
	if gpt3Err.StatusCode == http.StatusTooManyRequests {
		if gpt3Err.RateLimitHeaders.RemainingRequests == 0 {
            // Wait until the the RPM limit resets
			time.Sleep(gpt3Err.RateLimitHeaders.ResetRequests)
		} else {
            // Wait until the the TPM limit resets
			time.Sleep(gpt3Err.RateLimitHeaders.ResetTokens)
		}
	}
}
```