### PR TITLE
#42 Deprecation of TextDavinci003Engine Model

### DIFF
--- a/gpt3.go
+++ b/gpt3.go
@@ -33,6 +33,7 @@ const (
 	GPT3Dot5Turbo             = "gpt-3.5-turbo"
 	GPT3Dot5Turbo0301         = "gpt-3.5-turbo-0301"
 	GPT3Dot5Turbo0613         = "gpt-3.5-turbo-0613"
+	GPT3Dot5TurboInstruct     = "gpt-3.5-turbo-instruct"
 	TextSimilarityAda001      = "text-similarity-ada-001"
 	TextSimilarityBabbage001  = "text-similarity-babbage-001"
 	TextSimilarityCurie001    = "text-similarity-curie-001"

--- a/gpt3.go
+++ b/gpt3.go
@@ -14,17 +14,9 @@ import (
 
 // Engine Types
 const (
-	TextAda001Engine     = "text-ada-001"
-	TextBabbage001Engine = "text-babbage-001"
-	TextCurie001Engine   = "text-curie-001"
-	TextDavinci001Engine = "text-davinci-001"
-	TextDavinci002Engine = "text-davinci-002"
-	TextDavinci003Engine = "text-davinci-003"
-	AdaEngine            = "ada"
-	BabbageEngine        = "babbage"
-	CurieEngine          = "curie"
-	DavinciEngine        = "davinci"
-	DefaultEngine        = DavinciEngine
+	Baggage002Engine = "babbage-002"
+	Davinci002Engine = "davinci-002"
+	DefaultEngine    = Davinci002Engine
 )
 
 type EmbeddingEngine string


### PR DESCRIPTION
#42 
For the text completions of openai the following models are deprecated as of 2024-01-04

```
TextAda001Engine     = "text-ada-001"
TextBabbage001Engine = "text-babbage-001"
TextCurie001Engine   = "text-curie-001"
TextDavinci001Engine = "text-davinci-001"
TextDavinci002Engine = "text-davinci-002"
TextDavinci003Engine = "text-davinci-003"
AdaEngine            = "ada"
BabbageEngine        = "babbage"
CurieEngine          = "curie"
DavinciEngine        = "davinci"
```

Reference
https://platform.openai.com/docs/deprecations/instructgpt-models
https://platform.openai.com/docs/deprecations/fine-tuning-gpt-models

Currently supported model is 
```
"gpt-3.5-turbo-instruct"
"babbage-002"
"davinci-002"
```